### PR TITLE
fix(gnome): limit actions count

### DIFF
--- a/rooms/usual/gnome.py
+++ b/rooms/usual/gnome.py
@@ -7,7 +7,7 @@ def get_actions(user):
 		actions.append(str(g))
 		g += 50
 
-	return actions
+	return actions[:10]
 
 
 def enter(user, reply):


### PR DESCRIPTION
Fix REPLY_MARKUP_TOO_LONG error
